### PR TITLE
np.float -> float

### DIFF
--- a/codet/evaluation/fsodeval.py
+++ b/codet/evaluation/fsodeval.py
@@ -57,7 +57,7 @@ def compute_average_precision(precision, recall):
     if not isinstance(precision, np.ndarray) or not isinstance(
             recall, np.ndarray):
         raise ValueError("precision and recall must be numpy array")
-    if precision.dtype != np.float or recall.dtype != np.float:
+    if precision.dtype != float or recall.dtype != float:
         raise ValueError("input must be float numpy array.")
     if len(precision) != len(recall):
         raise ValueError("precision and recall must be of the same size.")
@@ -418,8 +418,8 @@ class FSODEval:
 
                 tps = np.logical_and(dt_m, np.logical_not(dt_ig))
                 fps = np.logical_and(np.logical_not(dt_m), np.logical_not(dt_ig))
-                tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
-                fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float)
+                tp_sum = np.cumsum(tps, axis=1).astype(dtype=float)
+                fp_sum = np.cumsum(fps, axis=1).astype(dtype=float)
 
                 dt_pointers[cat_idx][area_idx] = {
                     "tps": tps,
@@ -448,8 +448,8 @@ class FSODEval:
                             pr[i - 1] = pr[i]
 
                     mAP = compute_average_precision(
-                        np.array(pr, np.float).reshape(-1),
-                        np.array(rc, np.float).reshape(-1))
+                        np.array(pr, float).reshape(-1),
+                        np.array(rc, float).reshape(-1))
                     precision[iou_thr_idx, :, cat_idx, area_idx] = mAP
 
         self.eval = {

--- a/codet/evaluation/inateval.py
+++ b/codet/evaluation/inateval.py
@@ -57,7 +57,7 @@ def compute_average_precision(precision, recall):
     if not isinstance(precision, np.ndarray) or not isinstance(
             recall, np.ndarray):
         raise ValueError("precision and recall must be numpy array")
-    if precision.dtype != np.float or recall.dtype != np.float:
+    if precision.dtype != float or recall.dtype != float:
         raise ValueError("input must be float numpy array.")
     if len(precision) != len(recall):
         raise ValueError("precision and recall must be of the same size.")
@@ -418,8 +418,8 @@ class INATEval:
 
                 tps = np.logical_and(dt_m, np.logical_not(dt_ig))
                 fps = np.logical_and(np.logical_not(dt_m), np.logical_not(dt_ig))
-                tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
-                fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float)
+                tp_sum = np.cumsum(tps, axis=1).astype(dtype=float)
+                fp_sum = np.cumsum(fps, axis=1).astype(dtype=float)
 
                 dt_pointers[cat_idx][area_idx] = {
                     "tps": tps,
@@ -448,8 +448,8 @@ class INATEval:
                             pr[i - 1] = pr[i]
 
                     mAP = compute_average_precision(
-                        np.array(pr, np.float).reshape(-1),
-                        np.array(rc, np.float).reshape(-1))
+                        np.array(pr, float).reshape(-1),
+                        np.array(rc, float).reshape(-1))
                     precision[iou_thr_idx, :, cat_idx, area_idx] = mAP
 
         self.eval = {

--- a/codet/evaluation/oideval.py
+++ b/codet/evaluation/oideval.py
@@ -56,7 +56,7 @@ def compute_average_precision(precision, recall):
   if not isinstance(precision, np.ndarray) or not isinstance(
       recall, np.ndarray):
     raise ValueError("precision and recall must be numpy array")
-  if precision.dtype != np.float or recall.dtype != np.float:
+  if precision.dtype != float or recall.dtype != float:
     raise ValueError("input must be float numpy array.")
   if len(precision) != len(recall):
     raise ValueError("precision and recall must be of the same size.")
@@ -446,8 +446,8 @@ class OIDEval:
 
                 tps = np.logical_and(dt_m, np.logical_not(dt_ig))
                 fps = np.logical_and(np.logical_not(dt_m), np.logical_not(dt_ig))
-                tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
-                fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float)
+                tp_sum = np.cumsum(tps, axis=1).astype(dtype=float)
+                fp_sum = np.cumsum(fps, axis=1).astype(dtype=float)
 
                 dt_pointers[cat_idx][area_idx] = {
                     "tps": tps,
@@ -476,8 +476,8 @@ class OIDEval:
                             pr[i - 1] = pr[i]
 
                     mAP = compute_average_precision(
-                        np.array(pr, np.float).reshape(-1), 
-                        np.array(rc, np.float).reshape(-1))
+                        np.array(pr, float).reshape(-1), 
+                        np.array(rc, float).reshape(-1))
                     precision[iou_thr_idx, :, cat_idx, area_idx] = mAP
 
         self.eval = {

--- a/detic/evaluation/fsodeval.py
+++ b/detic/evaluation/fsodeval.py
@@ -57,7 +57,7 @@ def compute_average_precision(precision, recall):
     if not isinstance(precision, np.ndarray) or not isinstance(
             recall, np.ndarray):
         raise ValueError("precision and recall must be numpy array")
-    if precision.dtype != np.float or recall.dtype != np.float:
+    if precision.dtype != float or recall.dtype != float:
         raise ValueError("input must be float numpy array.")
     if len(precision) != len(recall):
         raise ValueError("precision and recall must be of the same size.")
@@ -418,8 +418,8 @@ class FSODEval:
 
                 tps = np.logical_and(dt_m, np.logical_not(dt_ig))
                 fps = np.logical_and(np.logical_not(dt_m), np.logical_not(dt_ig))
-                tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
-                fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float)
+                tp_sum = np.cumsum(tps, axis=1).astype(dtype=float)
+                fp_sum = np.cumsum(fps, axis=1).astype(dtype=float)
 
                 dt_pointers[cat_idx][area_idx] = {
                     "tps": tps,
@@ -448,8 +448,8 @@ class FSODEval:
                             pr[i - 1] = pr[i]
 
                     mAP = compute_average_precision(
-                        np.array(pr, np.float).reshape(-1),
-                        np.array(rc, np.float).reshape(-1))
+                        np.array(pr, float).reshape(-1),
+                        np.array(rc, float).reshape(-1))
                     precision[iou_thr_idx, :, cat_idx, area_idx] = mAP
 
         self.eval = {

--- a/detic/evaluation/inateval.py
+++ b/detic/evaluation/inateval.py
@@ -57,7 +57,7 @@ def compute_average_precision(precision, recall):
     if not isinstance(precision, np.ndarray) or not isinstance(
             recall, np.ndarray):
         raise ValueError("precision and recall must be numpy array")
-    if precision.dtype != np.float or recall.dtype != np.float:
+    if precision.dtype != float or recall.dtype != float:
         raise ValueError("input must be float numpy array.")
     if len(precision) != len(recall):
         raise ValueError("precision and recall must be of the same size.")
@@ -418,8 +418,8 @@ class INATEval:
 
                 tps = np.logical_and(dt_m, np.logical_not(dt_ig))
                 fps = np.logical_and(np.logical_not(dt_m), np.logical_not(dt_ig))
-                tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
-                fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float)
+                tp_sum = np.cumsum(tps, axis=1).astype(dtype=float)
+                fp_sum = np.cumsum(fps, axis=1).astype(dtype=float)
 
                 dt_pointers[cat_idx][area_idx] = {
                     "tps": tps,
@@ -448,8 +448,8 @@ class INATEval:
                             pr[i - 1] = pr[i]
 
                     mAP = compute_average_precision(
-                        np.array(pr, np.float).reshape(-1),
-                        np.array(rc, np.float).reshape(-1))
+                        np.array(pr, float).reshape(-1),
+                        np.array(rc, float).reshape(-1))
                     precision[iou_thr_idx, :, cat_idx, area_idx] = mAP
 
         self.eval = {

--- a/detic/evaluation/oideval.py
+++ b/detic/evaluation/oideval.py
@@ -57,7 +57,7 @@ def compute_average_precision(precision, recall):
     if not isinstance(precision, np.ndarray) or not isinstance(
             recall, np.ndarray):
         raise ValueError("precision and recall must be numpy array")
-    if precision.dtype != np.float or recall.dtype != np.float:
+    if precision.dtype != float or recall.dtype != float:
         raise ValueError("input must be float numpy array.")
     if len(precision) != len(recall):
         raise ValueError("precision and recall must be of the same size.")
@@ -453,8 +453,8 @@ class OIDEval:
 
                 tps = np.logical_and(dt_m, np.logical_not(dt_ig))
                 fps = np.logical_and(np.logical_not(dt_m), np.logical_not(dt_ig))
-                tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
-                fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float)
+                tp_sum = np.cumsum(tps, axis=1).astype(dtype=float)
+                fp_sum = np.cumsum(fps, axis=1).astype(dtype=float)
 
                 dt_pointers[cat_idx][area_idx] = {
                     "tps": tps,
@@ -483,8 +483,8 @@ class OIDEval:
                             pr[i - 1] = pr[i]
 
                     mAP = compute_average_precision(
-                        np.array(pr, np.float).reshape(-1),
-                        np.array(rc, np.float).reshape(-1))
+                        np.array(pr, float).reshape(-1),
+                        np.array(rc, float).reshape(-1))
                     precision[iou_thr_idx, :, cat_idx, area_idx] = mAP
 
         self.eval = {

--- a/vldet/evaluation/fsodeval.py
+++ b/vldet/evaluation/fsodeval.py
@@ -57,7 +57,7 @@ def compute_average_precision(precision, recall):
     if not isinstance(precision, np.ndarray) or not isinstance(
             recall, np.ndarray):
         raise ValueError("precision and recall must be numpy array")
-    if precision.dtype != np.float or recall.dtype != np.float:
+    if precision.dtype != float or recall.dtype != float:
         raise ValueError("input must be float numpy array.")
     if len(precision) != len(recall):
         raise ValueError("precision and recall must be of the same size.")
@@ -418,8 +418,8 @@ class FSODEval:
 
                 tps = np.logical_and(dt_m, np.logical_not(dt_ig))
                 fps = np.logical_and(np.logical_not(dt_m), np.logical_not(dt_ig))
-                tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
-                fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float)
+                tp_sum = np.cumsum(tps, axis=1).astype(dtype=float)
+                fp_sum = np.cumsum(fps, axis=1).astype(dtype=float)
 
                 dt_pointers[cat_idx][area_idx] = {
                     "tps": tps,
@@ -448,8 +448,8 @@ class FSODEval:
                             pr[i - 1] = pr[i]
 
                     mAP = compute_average_precision(
-                        np.array(pr, np.float).reshape(-1),
-                        np.array(rc, np.float).reshape(-1))
+                        np.array(pr, float).reshape(-1),
+                        np.array(rc, float).reshape(-1))
                     precision[iou_thr_idx, :, cat_idx, area_idx] = mAP
 
         self.eval = {

--- a/vldet/evaluation/inateval.py
+++ b/vldet/evaluation/inateval.py
@@ -57,7 +57,7 @@ def compute_average_precision(precision, recall):
     if not isinstance(precision, np.ndarray) or not isinstance(
             recall, np.ndarray):
         raise ValueError("precision and recall must be numpy array")
-    if precision.dtype != np.float or recall.dtype != np.float:
+    if precision.dtype != float or recall.dtype != float:
         raise ValueError("input must be float numpy array.")
     if len(precision) != len(recall):
         raise ValueError("precision and recall must be of the same size.")
@@ -418,8 +418,8 @@ class INATEval:
 
                 tps = np.logical_and(dt_m, np.logical_not(dt_ig))
                 fps = np.logical_and(np.logical_not(dt_m), np.logical_not(dt_ig))
-                tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
-                fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float)
+                tp_sum = np.cumsum(tps, axis=1).astype(dtype=float)
+                fp_sum = np.cumsum(fps, axis=1).astype(dtype=float)
 
                 dt_pointers[cat_idx][area_idx] = {
                     "tps": tps,
@@ -448,8 +448,8 @@ class INATEval:
                             pr[i - 1] = pr[i]
 
                     mAP = compute_average_precision(
-                        np.array(pr, np.float).reshape(-1),
-                        np.array(rc, np.float).reshape(-1))
+                        np.array(pr, float).reshape(-1),
+                        np.array(rc, float).reshape(-1))
                     precision[iou_thr_idx, :, cat_idx, area_idx] = mAP
 
         self.eval = {

--- a/vldet/evaluation/oideval.py
+++ b/vldet/evaluation/oideval.py
@@ -56,7 +56,7 @@ def compute_average_precision(precision, recall):
   if not isinstance(precision, np.ndarray) or not isinstance(
       recall, np.ndarray):
     raise ValueError("precision and recall must be numpy array")
-  if precision.dtype != np.float or recall.dtype != np.float:
+  if precision.dtype != float or recall.dtype != float:
     raise ValueError("input must be float numpy array.")
   if len(precision) != len(recall):
     raise ValueError("precision and recall must be of the same size.")
@@ -446,8 +446,8 @@ class OIDEval:
 
                 tps = np.logical_and(dt_m, np.logical_not(dt_ig))
                 fps = np.logical_and(np.logical_not(dt_m), np.logical_not(dt_ig))
-                tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
-                fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float)
+                tp_sum = np.cumsum(tps, axis=1).astype(dtype=float)
+                fp_sum = np.cumsum(fps, axis=1).astype(dtype=float)
 
                 dt_pointers[cat_idx][area_idx] = {
                     "tps": tps,
@@ -476,8 +476,8 @@ class OIDEval:
                             pr[i - 1] = pr[i]
 
                     mAP = compute_average_precision(
-                        np.array(pr, np.float).reshape(-1), 
-                        np.array(rc, np.float).reshape(-1))
+                        np.array(pr, float).reshape(-1), 
+                        np.array(rc, float).reshape(-1))
                     precision[iou_thr_idx, :, cat_idx, area_idx] = mAP
 
         self.eval = {


### PR DESCRIPTION
np.float was a deprecated alias for the builtin float.

The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations